### PR TITLE
Fix grade addition when subject is collapsed

### DIFF
--- a/src/components/SubjectCard.tsx
+++ b/src/components/SubjectCard.tsx
@@ -65,6 +65,9 @@ export const SubjectCard = ({
       return;
     }
     setIsAddingGrade(!isAddingGrade);
+    if (!isOpen) {
+      setIsOpen(true);
+    }
   };
 
   return (


### PR DESCRIPTION
Update `handleGradeAction` function to expand subject when adding a grade.

* Set `isOpen` to true when `isAddingGrade` is set to true and the subject is not already open.
