### PR TITLE
Group subjects by type and trigger grade creation dialog

### DIFF
--- a/src/components/SubjectCard.tsx
+++ b/src/components/SubjectCard.tsx
@@ -67,7 +67,7 @@ export const SubjectCard = ({
     if (!isOpen) {
       setIsOpen(true);
     }
-    setIsAddingGrade(true);
+    setIsAddingGrade(!isAddingGrade);
   };
 
   return (

--- a/src/components/SubjectCard.tsx
+++ b/src/components/SubjectCard.tsx
@@ -64,7 +64,10 @@ export const SubjectCard = ({
       setShowLoginDialog(true);
       return;
     }
-    setIsAddingGrade(!isAddingGrade);
+    if (!isOpen) {
+      setIsOpen(true);
+    }
+    setIsAddingGrade(true);
   };
 
   return (

--- a/src/components/SubjectList.tsx
+++ b/src/components/SubjectList.tsx
@@ -30,20 +30,49 @@ export const SubjectList = ({
     );
   }
 
+  const mainSubjects = subjects.filter(subject => subject.type === 'main');
+  const secondarySubjects = subjects.filter(subject => subject.type === 'secondary');
+
   return (
-    <div className="grid gap-4">
-      {subjects.map((subject) => (
-        <SubjectCard
-          key={subject.id}
-          subject={subject}
-          onAddGrade={onAddGrade}
-          onUpdateGrade={onUpdateGrade}
-          onDeleteGrade={onDeleteGrade}
-          onDeleteSubject={onDeleteSubject}
-          onUpdateSubject={onUpdateSubject}
-          isDemo={isDemo}
-        />
-      ))}
+    <div className="space-y-6">
+      {mainSubjects.length > 0 && (
+        <div>
+          <h2 className="text-lg font-semibold mb-4">Hauptfächer</h2>
+          <div className="grid gap-4">
+            {mainSubjects.map((subject) => (
+              <SubjectCard
+                key={subject.id}
+                subject={subject}
+                onAddGrade={onAddGrade}
+                onUpdateGrade={onUpdateGrade}
+                onDeleteGrade={onDeleteGrade}
+                onDeleteSubject={onDeleteSubject}
+                onUpdateSubject={onUpdateSubject}
+                isDemo={isDemo}
+              />
+            ))}
+          </div>
+        </div>
+      )}
+      {secondarySubjects.length > 0 && (
+        <div>
+          <h2 className="text-lg font-semibold mb-4">Nebenfächer</h2>
+          <div className="grid gap-4">
+            {secondarySubjects.map((subject) => (
+              <SubjectCard
+                key={subject.id}
+                subject={subject}
+                onAddGrade={onAddGrade}
+                onUpdateGrade={onUpdateGrade}
+                onDeleteGrade={onDeleteGrade}
+                onDeleteSubject={onDeleteSubject}
+                onUpdateSubject={onUpdateSubject}
+                isDemo={isDemo}
+              />
+            ))}
+          </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/src/components/SubjectList.tsx
+++ b/src/components/SubjectList.tsx
@@ -3,6 +3,7 @@ import { SubjectCard } from './SubjectCard';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
 import { Button } from '@/components/ui/button';
 import { ChevronDownIcon, ChevronUpIcon } from 'lucide-react';
+import { calculateSubjectAverage } from '@/lib/calculations';
 
 interface SubjectListProps {
   subjects: Subject[];
@@ -79,16 +80,20 @@ export const SubjectList = ({
           <CollapsibleContent>
             <div className="grid gap-4">
               {secondarySubjects.map((subject) => (
-                <SubjectCard
-                  key={subject.id}
-                  subject={subject}
-                  onAddGrade={onAddGrade}
-                  onUpdateGrade={onUpdateGrade}
-                  onDeleteGrade={onDeleteGrade}
-                  onDeleteSubject={onDeleteSubject}
-                  onUpdateSubject={onUpdateSubject}
-                  isDemo={isDemo}
-                />
+                <div key={subject.id}>
+                  <SubjectCard
+                    subject={subject}
+                    onAddGrade={onAddGrade}
+                    onUpdateGrade={onUpdateGrade}
+                    onDeleteGrade={onDeleteGrade}
+                    onDeleteSubject={onDeleteSubject}
+                    onUpdateSubject={onUpdateSubject}
+                    isDemo={isDemo}
+                  />
+                  <div className="text-right text-sm text-gray-500 mt-2">
+                    Durchschnitt: {calculateSubjectAverage(subject.grades)}
+                  </div>
+                </div>
               ))}
             </div>
           </CollapsibleContent>

--- a/src/components/SubjectList.tsx
+++ b/src/components/SubjectList.tsx
@@ -1,5 +1,8 @@
 import { Subject, Grade } from '@/types';
 import { SubjectCard } from './SubjectCard';
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
+import { Button } from '@/components/ui/button';
+import { ChevronDownIcon, ChevronUpIcon } from 'lucide-react';
 
 interface SubjectListProps {
   subjects: Subject[];
@@ -36,42 +39,60 @@ export const SubjectList = ({
   return (
     <div className="space-y-6">
       {mainSubjects.length > 0 && (
-        <div>
-          <h2 className="text-lg font-semibold mb-4">Hauptfächer</h2>
-          <div className="grid gap-4">
-            {mainSubjects.map((subject) => (
-              <SubjectCard
-                key={subject.id}
-                subject={subject}
-                onAddGrade={onAddGrade}
-                onUpdateGrade={onUpdateGrade}
-                onDeleteGrade={onDeleteGrade}
-                onDeleteSubject={onDeleteSubject}
-                onUpdateSubject={onUpdateSubject}
-                isDemo={isDemo}
-              />
-            ))}
+        <Collapsible>
+          <div className="flex items-center justify-between">
+            <h2 className="text-lg font-semibold mb-4">Hauptfächer</h2>
+            <CollapsibleTrigger asChild>
+              <Button variant="ghost" size="icon" className="h-8 w-8">
+                <ChevronDownIcon className="h-4 w-4" />
+              </Button>
+            </CollapsibleTrigger>
           </div>
-        </div>
+          <CollapsibleContent>
+            <div className="grid gap-4">
+              {mainSubjects.map((subject) => (
+                <SubjectCard
+                  key={subject.id}
+                  subject={subject}
+                  onAddGrade={onAddGrade}
+                  onUpdateGrade={onUpdateGrade}
+                  onDeleteGrade={onDeleteGrade}
+                  onDeleteSubject={onDeleteSubject}
+                  onUpdateSubject={onUpdateSubject}
+                  isDemo={isDemo}
+                />
+              ))}
+            </div>
+          </CollapsibleContent>
+        </Collapsible>
       )}
       {secondarySubjects.length > 0 && (
-        <div>
-          <h2 className="text-lg font-semibold mb-4">Nebenfächer</h2>
-          <div className="grid gap-4">
-            {secondarySubjects.map((subject) => (
-              <SubjectCard
-                key={subject.id}
-                subject={subject}
-                onAddGrade={onAddGrade}
-                onUpdateGrade={onUpdateGrade}
-                onDeleteGrade={onDeleteGrade}
-                onDeleteSubject={onDeleteSubject}
-                onUpdateSubject={onUpdateSubject}
-                isDemo={isDemo}
-              />
-            ))}
+        <Collapsible>
+          <div className="flex items-center justify-between">
+            <h2 className="text-lg font-semibold mb-4">Nebenfächer</h2>
+            <CollapsibleTrigger asChild>
+              <Button variant="ghost" size="icon" className="h-8 w-8">
+                <ChevronDownIcon className="h-4 w-4" />
+              </Button>
+            </CollapsibleTrigger>
           </div>
-        </div>
+          <CollapsibleContent>
+            <div className="grid gap-4">
+              {secondarySubjects.map((subject) => (
+                <SubjectCard
+                  key={subject.id}
+                  subject={subject}
+                  onAddGrade={onAddGrade}
+                  onUpdateGrade={onUpdateGrade}
+                  onDeleteGrade={onDeleteGrade}
+                  onDeleteSubject={onDeleteSubject}
+                  onUpdateSubject={onUpdateSubject}
+                  isDemo={isDemo}
+                />
+              ))}
+            </div>
+          </CollapsibleContent>
+        </Collapsible>
       )}
     </div>
   );

--- a/src/components/SubjectList.tsx
+++ b/src/components/SubjectList.tsx
@@ -3,7 +3,6 @@ import { SubjectCard } from './SubjectCard';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
 import { Button } from '@/components/ui/button';
 import { ChevronDownIcon, ChevronUpIcon } from 'lucide-react';
-import { calculateSubjectAverage } from '@/lib/calculations';
 
 interface SubjectListProps {
   subjects: Subject[];
@@ -80,20 +79,16 @@ export const SubjectList = ({
           <CollapsibleContent>
             <div className="grid gap-4">
               {secondarySubjects.map((subject) => (
-                <div key={subject.id}>
-                  <SubjectCard
-                    subject={subject}
-                    onAddGrade={onAddGrade}
-                    onUpdateGrade={onUpdateGrade}
-                    onDeleteGrade={onDeleteGrade}
-                    onDeleteSubject={onDeleteSubject}
-                    onUpdateSubject={onUpdateSubject}
-                    isDemo={isDemo}
-                  />
-                  <div className="text-right text-sm text-gray-500 mt-2">
-                    Durchschnitt: {calculateSubjectAverage(subject.grades)}
-                  </div>
-                </div>
+                <SubjectCard
+                  key={subject.id}
+                  subject={subject}
+                  onAddGrade={onAddGrade}
+                  onUpdateGrade={onUpdateGrade}
+                  onDeleteGrade={onDeleteGrade}
+                  onDeleteSubject={onDeleteSubject}
+                  onUpdateSubject={onUpdateSubject}
+                  isDemo={isDemo}
+                />
               ))}
             </div>
           </CollapsibleContent>


### PR DESCRIPTION
Group subjects by main and secondary in the subject overview and trigger grade creation dialog when "+" button is clicked.

* Update `src/components/SubjectList.tsx` to group subjects by their type (main or secondary) and add sections for main and secondary subjects.
* Update `src/components/SubjectCard.tsx` to trigger the grade creation dialog when the "+" button is clicked, even if the subject is collapsed, and ensure the subject is expanded when the "+" button is clicked.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/SchBenedikt/noten/pull/6?shareId=78d7d0e8-90c6-4f87-9c70-61f450ed4d15).