### PR TITLE
Fix content shift when expanding/collapsing sections

### DIFF
--- a/src/components/SubjectCard.tsx
+++ b/src/components/SubjectCard.tsx
@@ -77,7 +77,7 @@ export const SubjectCard = ({
       <Collapsible open={isOpen} onOpenChange={setIsOpen}>
         <CardHeader className="flex flex-col sm:flex-row items-start sm:items-center justify-between space-y-4 sm:space-y-0 p-4 sm:p-6">
           <div className="flex items-center gap-2">
-            <CollapsibleTrigger asChild>
+            <CollapsibleTrigger asChild className="overflow-hidden">
               <Button variant="ghost" size="icon" className="h-8 w-8">
                 {isOpen ? <ChevronUpIcon className="h-4 w-4" /> : <ChevronDownIcon className="h-4 w-4" />}
               </Button>
@@ -157,7 +157,7 @@ export const SubjectCard = ({
             </div>
           </div>
         </CardHeader>
-        <CollapsibleContent>
+        <CollapsibleContent className="overflow-hidden">
           <CardContent className="space-y-4 p-4 sm:p-6">
             {isAddingGrade && (
               <div className="bg-gray-50 p-4 rounded-lg">

--- a/src/components/SubjectForm.tsx
+++ b/src/components/SubjectForm.tsx
@@ -80,11 +80,11 @@ export const SubjectForm = ({ onSubmit }: SubjectFormProps) => {
                 defaultValue={field.value}
               >
                 <FormControl>
-                  <SelectTrigger>
+                  <SelectTrigger className="overflow-hidden">
                     <SelectValue placeholder="Wähle die Art des Fachs" />
                   </SelectTrigger>
                 </FormControl>
-                <SelectContent>
+                <SelectContent className="overflow-hidden">
                   <SelectItem value="main">Hauptfach</SelectItem>
                   <SelectItem value="secondary">Nebenfach</SelectItem>
                 </SelectContent>

--- a/src/components/SubjectList.tsx
+++ b/src/components/SubjectList.tsx
@@ -44,13 +44,13 @@ export const SubjectList = ({
         <div className="bg-white rounded-lg shadow-sm p-4 mb-4">
           <div className="flex items-center justify-between mb-4">
             <h2 className="text-lg font-semibold text-gray-800">{title}</h2>
-            <CollapsibleTrigger asChild>
+            <CollapsibleTrigger asChild className="overflow-hidden">
               <Button variant="ghost" size="icon" className="h-8 w-8 hover:bg-gray-100">
                 <ChevronDownIcon className="h-4 w-4" />
               </Button>
             </CollapsibleTrigger>
           </div>
-          <CollapsibleContent>
+          <CollapsibleContent className="overflow-hidden">
             <div className="grid gap-4">
               {subjects.map((subject) => (
                 <SubjectCard

--- a/src/components/ui/accordion.tsx
+++ b/src/components/ui/accordion.tsx
@@ -26,7 +26,7 @@ const AccordionTrigger = React.forwardRef<
     <AccordionPrimitive.Trigger
       ref={ref}
       className={cn(
-        "flex flex-1 items-center justify-between py-4 font-medium transition-all hover:underline [&[data-state=open]>svg]:rotate-180",
+        "flex flex-1 items-center justify-between py-4 font-medium transition-all hover:underline [&[data-state=open]>svg]:rotate-180 overflow-hidden",
         className
       )}
       {...props}
@@ -44,7 +44,7 @@ const AccordionContent = React.forwardRef<
 >(({ className, children, ...props }, ref) => (
   <AccordionPrimitive.Content
     ref={ref}
-    className="overflow-hidden text-sm transition-all data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down"
+    className="overflow-hidden text-sm transition-all data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down overflow-hidden"
     {...props}
   >
     <div className={cn("pb-4 pt-0", className)}>{children}</div>


### PR DESCRIPTION
Fix the issue where expanding "Hauptfächer" or "Nebenfächer" causes content to shift left.

* **Accordion Component**
  - Add `overflow-hidden` class to `AccordionPrimitive.Trigger` and `AccordionPrimitive.Content` to prevent content shift.

* **SubjectCard Component**
  - Add `overflow-hidden` class to `CollapsibleTrigger` and `CollapsibleContent` to prevent content shift.

* **SubjectList Component**
  - Add `overflow-hidden` class to `CollapsibleTrigger` and `CollapsibleContent` to prevent content shift.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/SchBenedikt/noten/pull/12?shareId=5db5b404-b353-4c04-ab52-128e294442bb).