### PR TITLE
Extend landing page with contrast color and more content

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -49,6 +49,8 @@
     --sidebar-border: 220 13% 91%;
 
     --sidebar-ring: 217.2 91.2% 59.8%;
+
+    --contrast: 340 65% 47%; /* P10b6 */
   }
 
   .dark {
@@ -87,6 +89,7 @@
     --sidebar-accent-foreground: 240 4.8% 95.9%;
     --sidebar-border: 240 3.7% 15.9%;
     --sidebar-ring: 217.2 91.2% 59.8%;
+    --contrast: 340 65% 47%; /* P10b6 */
   }
 
   /* Always show scrollbar to prevent layout shifts */
@@ -115,4 +118,8 @@
   body {
     @apply bg-background text-foreground;
   }
+
+  .contrast-text { /* Pdac9 */
+    color: hsl(var(--contrast)); /* Pdac9 */
+  } /* Pdac9 */
 }

--- a/src/pages/Landing.tsx
+++ b/src/pages/Landing.tsx
@@ -136,6 +136,11 @@ const Landing = () => {
               />
             </div>
           </div>
+
+          <footer className="mt-16 text-center text-sm text-muted-foreground">
+            <p className="contrast-text">© 2024 Benedikt Schächner. Alle Rechte vorbehalten.</p>
+            <p className="contrast-text">Domain: benedikt.schächner.de</p>
+          </footer>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Extend the landing page to include a contrast color and additional content.

* **CSS Changes:**
  - Define a new CSS variable for the contrast color in `src/index.css`.
  - Add a CSS rule to use the contrast color for specific elements with the class `contrast-text`.

* **Landing Page Changes:**
  - Update `src/pages/Landing.tsx` to use the new contrast color for specific elements.
  - Add a footer with copyright information and domain details.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/SchBenedikt/noten/pull/15?shareId=e1f77995-6bb1-4419-87bf-a8007ad29e8a).