### PR TITLE
Fix subject add error in sheet

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -177,14 +177,6 @@ const Index = () => {
           </div>
 
           <div className="space-y-6">
-            <SubjectSearch
-              searchQuery=""
-              searchType="subject"
-              onSearchChange={() => {}}
-              onSearchTypeChange={() => {}}
-              onSubjectAdd={onSubjectAdd}
-              currentGradeLevel={currentGradeLevel}
-            />
             <SubjectList
               subjects={currentSubjects}
               onAddGrade={addGrade}

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -177,6 +177,14 @@ const Index = () => {
           </div>
 
           <div className="space-y-6">
+            <SubjectSearch
+              searchQuery=""
+              searchType="subject"
+              onSearchChange={() => {}}
+              onSearchTypeChange={() => {}}
+              onSubjectAdd={onSubjectAdd}
+              currentGradeLevel={currentGradeLevel}
+            />
             <SubjectList
               subjects={currentSubjects}
               onAddGrade={addGrade}

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -20,6 +20,7 @@ import {
 import { useState, useEffect } from 'react';
 import { motion } from 'framer-motion';
 import CountUp from 'react-countup';
+import { SubjectSearch } from '@/components/SubjectSearch';
 
 const Index = () => {
   const {
@@ -56,6 +57,10 @@ const Index = () => {
 
   const handleUpdateSubject = async (subjectId: string, updates: Partial<Subject>) => {
     await updateSubject(subjectId, updates);
+  };
+
+  const onSubjectAdd = async (subject: Omit<Subject, 'id' | 'grades'>) => {
+    await addSubject(subject);
   };
 
   const currentSubjects = subjects.filter(s => s.grade_level === currentGradeLevel);
@@ -172,6 +177,14 @@ const Index = () => {
           </div>
 
           <div className="space-y-6">
+            <SubjectSearch
+              searchQuery=""
+              searchType="subject"
+              onSearchChange={() => {}}
+              onSearchTypeChange={() => {}}
+              onSubjectAdd={onSubjectAdd}
+              currentGradeLevel={currentGradeLevel}
+            />
             <SubjectList
               subjects={currentSubjects}
               onAddGrade={addGrade}


### PR DESCRIPTION
Fix the 'Unhandled Promise Rejection: TypeError: onSubjectAdd is not a function' error when adding subjects in the sheet.

* **Index.tsx**
  - Import `SubjectSearch` component.
  - Define `onSubjectAdd` function to call `addSubject` from `useSubjects`.
  - Pass `onSubjectAdd` function as a prop to the `SubjectSearch` component.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/SchBenedikt/noten/pull/21?shareId=686de159-ade5-4f78-bf35-e9abf52d0d14).