### PR TITLE
Fix awards check on dashboard page

### DIFF
--- a/src/hooks/use-achievements.ts
+++ b/src/hooks/use-achievements.ts
@@ -17,3 +17,37 @@ export const useAchievements = () => {
     },
   });
 };
+
+export const checkAndCreateAwards = async (userId: string) => {
+  const { data: awards, error } = await supabase
+    .from("awards")
+    .select("*")
+    .eq("user_id", userId);
+
+  if (error) {
+    console.error("Error fetching awards:", error);
+    return;
+  }
+
+  if (awards.length === 0) {
+    await createAwards(userId);
+  }
+};
+
+export const createAwards = async (userId: string) => {
+  const { error } = await supabase
+    .from("awards")
+    .insert([
+      { user_id: userId, type: "first_grade" },
+      { user_id: userId, type: "grade_streak" },
+      { user_id: userId, type: "perfect_grade" },
+      { user_id: userId, type: "improvement" },
+      { user_id: userId, type: "subject_master" },
+      { user_id: userId, type: "grade_collector" },
+      { user_id: userId, type: "subject_collector" },
+    ]);
+
+  if (error) {
+    console.error("Error creating awards:", error);
+  }
+};

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -68,6 +68,47 @@ const Index = () => {
     setStartCount(true);
   }, []);
 
+  useEffect(() => {
+    const checkAndCreateAwards = async () => {
+      const { data: { user } } = await supabase.auth.getUser();
+      if (!user) return;
+
+      const { data: awards, error } = await supabase
+        .from("awards")
+        .select("*")
+        .eq("user_id", user.id);
+
+      if (error) {
+        console.error("Error fetching awards:", error);
+        return;
+      }
+
+      if (awards.length === 0) {
+        await createAwards(user.id);
+      }
+    };
+
+    checkAndCreateAwards();
+  }, []);
+
+  const createAwards = async (userId: string) => {
+    const { error } = await supabase
+      .from("awards")
+      .insert([
+        { user_id: userId, type: "first_grade" },
+        { user_id: userId, type: "grade_streak" },
+        { user_id: userId, type: "perfect_grade" },
+        { user_id: userId, type: "improvement" },
+        { user_id: userId, type: "subject_master" },
+        { user_id: userId, type: "grade_collector" },
+        { user_id: userId, type: "subject_collector" },
+      ]);
+
+    if (error) {
+      console.error("Error creating awards:", error);
+    }
+  };
+
   const handleLogout = async () => {
     const { error } = await supabase.auth.signOut();
     if (error) {


### PR DESCRIPTION
Add functionality to check and create awards if they don't exist when loading the dashboard page.

* **`src/pages/Index.tsx`**
  - Add a `useEffect` hook to check if awards need to be created.
  - Add a function `createAwards` to create awards if they don't exist.
  - Call the `checkAndCreateAwards` function within the `useEffect` hook.

* **`src/hooks/use-achievements.ts`**
  - Add a function `checkAndCreateAwards` to check if awards need to be created.
  - Add a function `createAwards` to create awards if they don't exist.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/SchBenedikt/noten/pull/23?shareId=57690ac9-4f54-41d9-94a0-061d2a7b659b).