### PR TITLE
Add admin page for managing badges

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import Profile from "./pages/Profile";
 import DatabaseSetup from "./pages/DatabaseSetup";
 import SelfHosting from "./pages/SelfHosting";
 import Achievements from "./pages/Achievements";
+import AdminAchievements from "./pages/AdminAchievements";
 import { useEffect, useState } from "react";
 import { supabase } from "@/integrations/supabase/client";
 import { Session } from "@supabase/supabase-js";
@@ -75,6 +76,16 @@ const App = () => {
               element={
                 session ? (
                   <Achievements />
+                ) : (
+                  <Navigate to="/login" replace />
+                )
+              }
+            />
+            <Route
+              path="/admin/achievements"
+              element={
+                session ? (
+                  <AdminAchievements />
                 ) : (
                   <Navigate to="/login" replace />
                 )

--- a/src/components/AchievementsList.tsx
+++ b/src/components/AchievementsList.tsx
@@ -1,11 +1,15 @@
 import { Achievement } from "@/types";
-import { Trophy, Star, TrendingUp, GraduationCap, BookOpen, Award, Medal } from "lucide-react";
+import { Trophy, Star, TrendingUp, GraduationCap, BookOpen, Award, Medal, Edit, Trash } from "lucide-react";
 import { motion } from "framer-motion";
 import { fetchAndCreateMissingAchievements } from "@/lib/achievements";
 import { useEffect } from "react";
+import { Button } from "@/components/ui/button";
+import { useLocation } from "react-router-dom";
 
 interface AchievementsListProps {
   achievements: Achievement[];
+  onEdit?: (achievement: Achievement) => void;
+  onDelete?: (achievementId: string) => void;
 }
 
 const achievementInfo = {
@@ -46,7 +50,10 @@ const achievementInfo = {
   },
 };
 
-export const AchievementsList = ({ achievements }: AchievementsListProps) => {
+export const AchievementsList = ({ achievements, onEdit, onDelete }: AchievementsListProps) => {
+  const location = useLocation();
+  const isAdminPage = location.pathname.includes("/admin");
+
   useEffect(() => {
     fetchAndCreateMissingAchievements();
   }, []);
@@ -75,13 +82,23 @@ export const AchievementsList = ({ achievements }: AchievementsListProps) => {
             <div className="bg-primary/10 p-2 rounded-full">
               <Icon className="h-6 w-6 text-primary" />
             </div>
-            <div className="p-2">
+            <div className="p-2 flex-1">
               <h3 className="font-medium">{info.title}</h3>
               <p className="text-sm text-gray-500">{info.description}</p>
               <p className="text-xs text-gray-400 mt-1">
                 {new Date(achievement.earned_at).toLocaleDateString()}
               </p>
             </div>
+            {isAdminPage && (
+              <div className="flex items-center gap-2">
+                <Button variant="outline" size="icon" onClick={() => onEdit?.(achievement)}>
+                  <Edit className="h-4 w-4" />
+                </Button>
+                <Button variant="destructive" size="icon" onClick={() => onDelete?.(achievement.id)}>
+                  <Trash className="h-4 w-4" />
+                </Button>
+              </div>
+            )}
           </motion.div>
         );
       })}

--- a/src/components/AdminAchievementForm.tsx
+++ b/src/components/AdminAchievementForm.tsx
@@ -1,0 +1,110 @@
+import { useState, useEffect } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import * as z from "zod";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Form, FormField, FormItem, FormLabel, FormControl, FormMessage } from "@/components/ui/form";
+import { useAchievements } from "@/hooks/use-achievements";
+
+const formSchema = z.object({
+  title: z.string().min(1, "Titel ist erforderlich"),
+  description: z.string().min(1, "Beschreibung ist erforderlich"),
+  type: z.string().min(1, "Typ ist erforderlich"),
+});
+
+export const AdminAchievementForm = ({ onSubmit, achievement, onUpdate, onDelete }) => {
+  const [isEditing, setIsEditing] = useState(false);
+  const { data: achievements, refetch } = useAchievements();
+
+  const form = useForm({
+    resolver: zodResolver(formSchema),
+    defaultValues: {
+      title: achievement?.title || "",
+      description: achievement?.description || "",
+      type: achievement?.type || "",
+    },
+  });
+
+  useEffect(() => {
+    if (achievement) {
+      setIsEditing(true);
+      form.reset({
+        title: achievement.title,
+        description: achievement.description,
+        type: achievement.type,
+      });
+    } else {
+      setIsEditing(false);
+      form.reset({
+        title: "",
+        description: "",
+        type: "",
+      });
+    }
+  }, [achievement, form]);
+
+  const handleFormSubmit = async (data) => {
+    if (isEditing) {
+      await onUpdate({ ...achievement, ...data });
+    } else {
+      await onSubmit(data);
+    }
+    refetch();
+    form.reset();
+  };
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(handleFormSubmit)} className="space-y-4">
+        <FormField
+          control={form.control}
+          name="title"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Titel</FormLabel>
+              <FormControl>
+                <Input {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="description"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Beschreibung</FormLabel>
+              <FormControl>
+                <Input {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="type"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Typ</FormLabel>
+              <FormControl>
+                <Input {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <div className="flex justify-end gap-2">
+          {isEditing && (
+            <Button variant="destructive" onClick={() => onDelete(achievement.id)}>
+              Löschen
+            </Button>
+          )}
+          <Button type="submit">{isEditing ? "Aktualisieren" : "Hinzufügen"}</Button>
+        </div>
+      </form>
+    </Form>
+  );
+};

--- a/src/hooks/use-achievements.ts
+++ b/src/hooks/use-achievements.ts
@@ -63,3 +63,44 @@ export const fetchAndCreateMissingAchievements = async () => {
     }
   }
 };
+
+export const addAchievement = async (achievement: Achievement) => {
+  const { data, error } = await supabase
+    .from('achievements')
+    .insert([achievement]);
+
+  if (error) {
+    console.error('Error adding achievement:', error);
+    throw error;
+  }
+
+  return data;
+};
+
+export const updateAchievement = async (achievement: Achievement) => {
+  const { data, error } = await supabase
+    .from('achievements')
+    .update(achievement)
+    .eq('id', achievement.id);
+
+  if (error) {
+    console.error('Error updating achievement:', error);
+    throw error;
+  }
+
+  return data;
+};
+
+export const deleteAchievement = async (achievementId: string) => {
+  const { data, error } = await supabase
+    .from('achievements')
+    .delete()
+    .eq('id', achievementId);
+
+  if (error) {
+    console.error('Error deleting achievement:', error);
+    throw error;
+  }
+
+  return data;
+};

--- a/src/pages/AdminAchievements.tsx
+++ b/src/pages/AdminAchievements.tsx
@@ -1,0 +1,81 @@
+import { useAchievements, addAchievement, updateAchievement, deleteAchievement } from "@/hooks/use-achievements";
+import { AdminAchievementForm } from "@/components/AdminAchievementForm";
+import { Button } from "@/components/ui/button";
+import { ArrowLeft } from "lucide-react";
+import { useNavigate } from "react-router-dom";
+import { useState } from "react";
+
+const AdminAchievements = () => {
+  const { data: achievements = [], isLoading } = useAchievements();
+  const navigate = useNavigate();
+  const [selectedAchievement, setSelectedAchievement] = useState(null);
+
+  const handleAddAchievement = async (achievement) => {
+    await addAchievement(achievement);
+  };
+
+  const handleUpdateAchievement = async (achievement) => {
+    await updateAchievement(achievement);
+  };
+
+  const handleDeleteAchievement = async (achievementId) => {
+    await deleteAchievement(achievementId);
+  };
+
+  if (isLoading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-gray-900"></div>
+        <p>Laden...</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50 py-4 sm:py-8">
+      <div className="container mx-auto px-2 sm:px-4">
+        <div className="flex items-center gap-4 mb-6">
+          <Button variant="ghost" size="icon" onClick={() => navigate(-1)}>
+            <ArrowLeft className="h-5 w-5" />
+          </Button>
+          <h1 className="text-3xl sm:text-4xl font-bold">Admin Auszeichnungen</h1>
+        </div>
+
+        <div className="space-y-6">
+          <div className="bg-white p-6 rounded-lg shadow-sm">
+            <AdminAchievementForm
+              onSubmit={handleAddAchievement}
+              achievement={selectedAchievement}
+              onUpdate={handleUpdateAchievement}
+              onDelete={handleDeleteAchievement}
+            />
+          </div>
+
+          <div className="bg-white p-6 rounded-lg shadow-sm">
+            <h2 className="text-2xl font-semibold mb-4">Bestehende Auszeichnungen</h2>
+            <ul className="space-y-4">
+              {achievements.map((achievement) => (
+                <li key={achievement.id} className="flex items-center justify-between">
+                  <div>
+                    <h3 className="text-lg font-medium">{achievement.title}</h3>
+                    <p className="text-sm text-gray-500">{achievement.description}</p>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <Button variant="outline" size="sm" onClick={() => setSelectedAchievement(achievement)}>
+                      Bearbeiten
+                    </Button>
+                    <Button variant="destructive" size="sm" onClick={() => handleDeleteAchievement(achievement.id)}>
+                      Löschen
+                    </Button>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default AdminAchievements;


### PR DESCRIPTION
Add an admin page for managing badges (Abzeichen) with functionalities to add, delete, and edit badges.

* **New Admin Page**: Add `src/pages/AdminAchievements.tsx` to create a new admin page for managing badges. Include functionalities to add, delete, and edit badges using `useAchievements` hook.
* **Routing**: Modify `src/App.tsx` to include a new route for the admin page at `/admin/achievements`. Import `AdminAchievements` component.
* **Admin Controls**: Modify `src/components/AchievementsList.tsx` to include admin controls (edit, delete) when accessed from the admin page. Add conditional rendering for admin controls.
* **Admin Form Component**: Add `src/components/AdminAchievementForm.tsx` to create a new component for adding and editing badges. Include form fields for badge details and use `useAchievements` hook for form submission.
* **Hook Updates**: Modify `src/hooks/use-achievements.ts` to add functions for adding, deleting, and updating badges. Export new functions for use in the admin page and form.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/SchBenedikt/noten/pull/25?shareId=f1719258-cb41-48d2-ab74-11df3cb7e864).